### PR TITLE
fix: Upgrade dotnet to avoid json not found

### DIFF
--- a/WeddingShare/Dockerfile
+++ b/WeddingShare/Dockerfile
@@ -1,10 +1,10 @@
 #See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS base
 WORKDIR /app
 EXPOSE 5000
 
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 ARG TARGETARCH
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src

--- a/WeddingShare/WeddingShare.csproj
+++ b/WeddingShare/WeddingShare.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>aspnet-WeddingShare-3190c778-4fc0-46f9-9259-fc6196c41c5a</UserSecretsId>


### PR DESCRIPTION
When generating thumbnails on videos an exception is thrown showing that System.Text.Json, Version=9 could not be found. 

This requirement seems to come from line 27 [here](https://github.com/tomaszzmuda/Xabe.FFmpeg/blob/41dc7027ee2bdbfe5ab70c74277f6fca1c07d0c4/src/Xabe.FFmpeg/Xabe.FFmpeg.csproj#L27)