### PR TITLE
Fix MySQL backend: Export/Import, Settings, and Value Casing

### DIFF
--- a/WeddingShare/Helpers/Database/MySqlDatabaseHelper.cs
+++ b/WeddingShare/Helpers/Database/MySqlDatabaseHelper.cs
@@ -1841,7 +1841,7 @@ namespace WeddingShare.Helpers.Database
             return new SettingModel()
             {
                 Id = model.Id.ToUpper(),
-                Value = null
+                Value = model.Value
             };
         }
 
@@ -2012,16 +2012,198 @@ namespace WeddingShare.Helpers.Database
         #region Backups
         public async Task<bool> Import(string path)
         {
-            return await Task.Run(() => {
-                return false;
-            });
+            bool result = false;
+
+            try
+            {
+                // Import from SQLite backup file into MySQL
+                // path is already a connection string like "Data Source=/path/to/file"
+                using (var sqliteConn = new Microsoft.Data.Sqlite.SqliteConnection(path))
+                {
+                    await sqliteConn.OpenAsync();
+
+                    using (var mysqlConn = await GetConnection())
+                    {
+                        await mysqlConn.OpenAsync();
+
+                        // Import in order respecting foreign keys
+                        await ImportTable(sqliteConn, mysqlConn, "users", 
+                            "SELECT id, username, email, password, failed_logins, lockout_until, [2fa_token], state, level, secret_code FROM users",
+                            "REPLACE INTO users (id, username, email, password, failed_logins, lockout_until, 2fa_token, state, level, secret_code) VALUES (@p0, @p1, @p2, @p3, @p4, @p5, @p6, @p7, @p8, @p9)");
+                        
+                        await ImportTable(sqliteConn, mysqlConn, "settings",
+                            "SELECT id, value FROM settings",
+                            "REPLACE INTO settings (id, value) VALUES (@p0, @p1)");
+                        
+                        await ImportTable(sqliteConn, mysqlConn, "galleries",
+                            "SELECT id, identifier, name, secret_key, owner FROM galleries",
+                            "REPLACE INTO galleries (id, identifier, name, secret_key, owner) VALUES (@p0, @p1, @p2, @p3, @p4)");
+                        
+                        await ImportTable(sqliteConn, mysqlConn, "gallery_items",
+                            "SELECT id, gallery_id, title, uploaded_by, state, media_type, checksum, orientation, uploaded_date, file_size, uploader_email FROM gallery_items",
+                            "REPLACE INTO gallery_items (id, gallery_id, title, uploaded_by, state, media_type, checksum, orientation, uploaded_date, file_size, uploader_email) VALUES (@p0, @p1, @p2, @p3, @p4, @p5, @p6, @p7, @p8, @p9, @p10)");
+                        
+                        await ImportTable(sqliteConn, mysqlConn, "gallery_likes",
+                            "SELECT id, gallery_item_id, identifier FROM gallery_likes",
+                            "REPLACE INTO gallery_likes (id, gallery_item_id, identifier) VALUES (@p0, @p1, @p2)");
+                        
+                        await ImportTable(sqliteConn, mysqlConn, "gallery_settings",
+                            "SELECT id, gallery_id, value FROM gallery_settings",
+                            "REPLACE INTO gallery_settings (id, gallery_id, value) VALUES (@p0, @p1, @p2)");
+                        
+                        await ImportTable(sqliteConn, mysqlConn, "custom_resources",
+                            "SELECT id, type, name, content, owner FROM custom_resources",
+                            "REPLACE INTO custom_resources (id, type, name, content, owner) VALUES (@p0, @p1, @p2, @p3, @p4)");
+                        
+                        await ImportTable(sqliteConn, mysqlConn, "audit_logs",
+                            "SELECT id, timestamp, username, action FROM audit_logs",
+                            "REPLACE INTO audit_logs (id, timestamp, username, action) VALUES (@p0, @p1, @p2, @p3)");
+
+                        await mysqlConn.CloseAsync();
+                    }
+
+                    await sqliteConn.CloseAsync();
+                }
+
+                result = true;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, $"Failed to import database - {ex?.Message}");
+            }
+
+            return result;
+        }
+
+        private async Task ImportTable(Microsoft.Data.Sqlite.SqliteConnection sqliteConn, MySqlConnection mysqlConn, string tableName, string selectQuery, string insertQuery)
+        {
+            try
+            {
+                using (var cmd = new Microsoft.Data.Sqlite.SqliteCommand(selectQuery, sqliteConn))
+                using (var reader = await cmd.ExecuteReaderAsync())
+                {
+                    while (await reader.ReadAsync())
+                    {
+                        using (var mysqlCmd = CreateCommand(insertQuery, mysqlConn))
+                        {
+                            for (int i = 0; i < reader.FieldCount; i++)
+                            {
+                                mysqlCmd.Parameters.AddWithValue($"@p{i}", reader.IsDBNull(i) ? DBNull.Value : reader.GetValue(i));
+                            }
+                            await mysqlCmd.ExecuteNonQueryAsync();
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, $"Failed to import table {tableName} - {ex?.Message}");
+            }
         }
 
         public async Task<bool> Export(string path)
         {
-            return await Task.Run(() => {
-                return false;
-            });
+            bool result = false;
+
+            try
+            {
+                // Export MySQL data to SQLite format for compatibility
+                // path is already a connection string like "Data Source=/path/to/file"
+                using (var sqliteConn = new Microsoft.Data.Sqlite.SqliteConnection(path))
+                {
+                    await sqliteConn.OpenAsync();
+
+                    // Create SQLite tables - use brackets for column names starting with numbers
+                    var createTables = @"
+                        CREATE TABLE IF NOT EXISTS galleries (id INTEGER PRIMARY KEY, identifier TEXT, name TEXT NOT NULL UNIQUE, secret_key TEXT, owner INTEGER DEFAULT 0);
+                        CREATE TABLE IF NOT EXISTS gallery_items (id INTEGER PRIMARY KEY, gallery_id INTEGER NOT NULL, title TEXT NOT NULL, uploaded_by TEXT, state INTEGER NOT NULL DEFAULT 0, media_type INTEGER DEFAULT 0, checksum TEXT, orientation INTEGER DEFAULT 0, uploaded_date TEXT, file_size INTEGER DEFAULT 0, uploader_email TEXT, FOREIGN KEY (gallery_id) REFERENCES galleries(id));
+                        CREATE TABLE IF NOT EXISTS gallery_likes (id INTEGER PRIMARY KEY, gallery_item_id INTEGER NOT NULL, identifier TEXT NOT NULL, FOREIGN KEY (gallery_item_id) REFERENCES gallery_items(id));
+                        CREATE TABLE IF NOT EXISTS gallery_settings (id TEXT NOT NULL, gallery_id INTEGER NOT NULL, value TEXT, PRIMARY KEY (id, gallery_id));
+                        CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY, username TEXT NOT NULL UNIQUE, email TEXT UNIQUE, password TEXT NOT NULL, failed_logins INTEGER DEFAULT 0, lockout_until TEXT, [2fa_token] TEXT, state INTEGER DEFAULT 0, level INTEGER DEFAULT 0, secret_code TEXT);
+                        CREATE TABLE IF NOT EXISTS settings (id TEXT PRIMARY KEY, value TEXT);
+                        CREATE TABLE IF NOT EXISTS custom_resources (id INTEGER PRIMARY KEY, type INTEGER NOT NULL, name TEXT NOT NULL, content BLOB, owner INTEGER DEFAULT 0);
+                        CREATE TABLE IF NOT EXISTS audit_logs (id INTEGER PRIMARY KEY, timestamp TEXT NOT NULL, username TEXT, action TEXT NOT NULL);
+                    ";
+                    using (var cmd = new Microsoft.Data.Sqlite.SqliteCommand(createTables, sqliteConn))
+                    {
+                        await cmd.ExecuteNonQueryAsync();
+                    }
+
+                    using (var mysqlConn = await GetConnection())
+                    {
+                        await mysqlConn.OpenAsync();
+
+                        // Export galleries
+                        await ExportTable(mysqlConn, sqliteConn, "galleries", "SELECT id, identifier, name, secret_key, owner FROM galleries");
+                        
+                        // Export gallery_items
+                        await ExportTable(mysqlConn, sqliteConn, "gallery_items", "SELECT id, gallery_id, title, uploaded_by, state, media_type, checksum, orientation, uploaded_date, file_size, uploader_email FROM gallery_items");
+                        
+                        // Export gallery_likes
+                        await ExportTable(mysqlConn, sqliteConn, "gallery_likes", "SELECT id, gallery_item_id, identifier FROM gallery_likes");
+                        
+                        // Export gallery_settings
+                        await ExportTable(mysqlConn, sqliteConn, "gallery_settings", "SELECT id, gallery_id, value FROM gallery_settings");
+                        
+                        // Export users
+                        await ExportTable(mysqlConn, sqliteConn, "users", "SELECT id, username, email, password, failed_logins, lockout_until, 2fa_token, state, level, secret_code FROM users");
+                        
+                        // Export settings
+                        await ExportTable(mysqlConn, sqliteConn, "settings", "SELECT id, value FROM settings");
+                        
+                        // Export custom_resources
+                        await ExportTable(mysqlConn, sqliteConn, "custom_resources", "SELECT id, type, name, content, owner FROM custom_resources");
+                        
+                        // Export audit_logs
+                        await ExportTable(mysqlConn, sqliteConn, "audit_logs", "SELECT id, timestamp, username, action FROM audit_logs");
+
+                        await mysqlConn.CloseAsync();
+                    }
+
+                    await sqliteConn.CloseAsync();
+                }
+
+                result = true;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, $"Failed to export database - {ex?.Message}");
+            }
+
+            return result;
+        }
+
+        private async Task ExportTable(MySqlConnection mysqlConn, Microsoft.Data.Sqlite.SqliteConnection sqliteConn, string tableName, string selectQuery)
+        {
+            try
+            {
+                using (var cmd = CreateCommand(selectQuery, mysqlConn))
+                using (var reader = await cmd.ExecuteReaderAsync())
+                {
+                    while (await reader.ReadAsync())
+                    {
+                        var columns = new List<string>();
+                        var parameters = new List<string>();
+                        var sqliteCmd = new Microsoft.Data.Sqlite.SqliteCommand();
+                        sqliteCmd.Connection = sqliteConn;
+
+                        for (int i = 0; i < reader.FieldCount; i++)
+                        {
+                            var colName = reader.GetName(i);
+                            columns.Add($"\"{colName}\"");
+                            parameters.Add($"@p{i}");
+                            sqliteCmd.Parameters.AddWithValue($"@p{i}", reader.IsDBNull(i) ? DBNull.Value : reader.GetValue(i));
+                        }
+
+                        sqliteCmd.CommandText = $"INSERT OR REPLACE INTO {tableName} ({string.Join(", ", columns)}) VALUES ({string.Join(", ", parameters)})";
+                        await sqliteCmd.ExecuteNonQueryAsync();
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, $"Failed to export table {tableName} - {ex?.Message}");
+            }
         }
         #endregion
 

--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,17 @@
 
  <br />![Banner](banner.png)
 
+> [!IMPORTANT]
+> **This project is under active development**
+> 
+> Whilst the last commit on this project has been months ago at this stage I just want to assure everyone that this project is still under active development. I am currently making large core changes to improve the overall look, feel and performance of the site as well as implement many new features that will provide an overall better user experience and end product.
+>
+> Whist this work continues in the background no new functionality will be added to the current project. Critical bugs and vulnerabilities will be patched but the next functionality update will be the new v2.0 release.
+>
+> All I ask from you is to sit back, relax and wait patiently while I do my hardest to create something bigger and better. I am trying my hardest to ensure all aspects of the new version are fully complete and fully polished rather than half broken or just downright bad features.
+> 
+> \- ***Cirx08***
+
 ## Support
 
 Thank you to everyone that supports this project. For anyone that hasn't yet I would be grateful if you would show some support by "buying me a coffee" through the link below. Weddings are expensive and all proceeds from this project will be going towards paying off my wedding bills.


### PR DESCRIPTION
## Summary
This PR fixes four bugs in the MySQL database helper that cause issues when using MySQL as the backend database and closes #178. I used Claude Opus to help me identify and fix the code for the issues I reported, but I manually applied the patch and validated the export file.

## Changes

### 1. Implement MySQL Export
The MySQL export was returning `false` without any implementation. This PR implements export functionality that creates a SQLite backup file for compatibility with the existing import system.

### 2. Implement MySQL Import
The MySQL import was also not implemented. This PR adds import functionality that reads from a SQLite backup file, enabling restore from backups and migration from SQLite to MySQL.

### 3. Fix Settings Update False Failure
The `SetSetting` method was returning `Value = null` in its fallback return, causing the controller to think the save failed even when it succeeded.

**Before:** Returns `Value = null` → UI shows "Failed to update settings"
**After:** Returns `Value = model.Value` → UI shows success

### 4. Fix Setting Values Forced to Lowercase
The `ReadSettings` method was calling `.ToLower()` on all setting values, causing titles and other settings to display in lowercase.

**Before:** `reader.GetString("value").ToLower()`
**After:** `reader.GetString("value")`

## Testing

Tested on Ubuntu 24.04 with Docker, using MySQL HeatWave (OCI) as the backend.

### Export Test
- Clicked "Export Data" in Account → Data tab
- Successfully downloaded `WeddingShare-2026-02-05_18-39-04.zip`
- Verified SQLite backup contains all tables: `galleries`, `gallery_items`, `gallery_likes`, `gallery_settings`, `users`, `settings`, `custom_resources`, `audit_logs`
- Compared with backup from SQLite installation - data matches (12 gallery items, 2 users, 1 gallery)

### Settings Test
- Changed title in settings
- Verified title displays with correct casing (no longer forced to lowercase)
- Database shows correct value: `Dylan & Kayelin`

### Title Casing Test
- Before fix the title returned in the body was lowercase
- After fix the title was returned in the proper casing.

## Related Issues
Fixes issues with MySQL backend where:
- Export Data always fails with `{"success":false}`
- Import Data always fails  
- Settings show "Failed to update settings" but actually save
- Title and other settings display as lowercase
